### PR TITLE
HEAD request to form URL resolves response when unauthorized

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -14,7 +14,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: mr-smithers-excellent/docker-build-push@v2
               with:
-                  image: enketo/enketo-express
+                  image: onaio/enketo-express
                   registry: docker.io
                   dockerfile: Dockerfile
                   username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -6,6 +6,12 @@ on:
         # usually releases
         tags:
             - '*'
+    workflow_dispatch:
+      inputs:
+          versionTag:
+              description: "Version Tag"
+              required: true
+              default: ''
 
 jobs:
     docker-build-push:

--- a/app/lib/communicator.js
+++ b/app/lib/communicator.js
@@ -345,6 +345,10 @@ function _request(options) {
                 debug(`Error occurred when requesting ${options.url}`, error);
                 reject(error);
             } else if (response.statusCode === 401) {
+                // resolve response if request method is HEAD
+                if (method === 'head') {
+                    resolve(response);
+                }
                 error = new Error('Forbidden. Authorization Required.');
                 error.status = response.statusCode;
                 reject(error);

--- a/test/server/communicator-lib.spec.js
+++ b/test/server/communicator-lib.spec.js
@@ -158,6 +158,24 @@ describe('Communicator Library', () => {
                 done();
             });
         });
+
+        it('should resolve with submission size when unauthenticated', (done) => {
+            const survey = {
+                info: {
+                    downloadUrl: 'https://testserver.com/foo',
+                },
+                credentials: { bearer: 'qwerty' },
+                cookie: 'abc',
+            };
+            nock('https://testserver.com')
+                .intercept('/foo', 'head')
+                .reply(401, {}, { 'x-openrosa-accept-content-length': '1024' });
+
+            communicator.getMaxSize(survey).then((response) => {
+                expect(response).to.equal('1024');
+                done();
+            });
+        });
     });
 
     describe('authenticate function', () => {


### PR DESCRIPTION
Signed-off-by: Kipchirchir Sigei <arapgodsmack@gmail.com>

Closes https://github.com/enketo/enketo/issues/994 , https://github.com/onaio/zebra/issues/6984

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [x] None of the above

#### What else has been done to verify that this works as intended?
- Added a test case to resolve response when a HEAD request to a form URL throws a 401

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.
